### PR TITLE
Rename Queries to QueryBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ decide on a strategy for service integration. Timeouts are _first-class
 citizens_ in the API, and protect against surprises.
 
 ```java
-  var authors = Queries.queryFor("authors", String.class)
+  var authors = QueryBuilder.queryFor("authors", String.class)
                   .waitingFor(800)
                   .orEmpty();
 ```
@@ -28,7 +28,7 @@ Defaults are suddenly top-of-mind for developers, and either the _empty case_
 is good enough, or fallbacks can be provided.
 
 ```java
-  var authors = Queries.queryFor("authors", String.class)
+  var authors = QueryBuilder.queryFor("authors", String.class)
                   .waitingFor(800)
                   .orDefaults(Authors.defaults());
 ```
@@ -37,7 +37,7 @@ Preserve resources, specific to the current needs and protect your services,
 by limiting the amount of data consumed.
 
 ```java
-  var authors = Queries.queryFor("authors", String.class)
+  var authors = QueryBuilder.queryFor("authors", String.class)
                   .takingAtMost(10)
                   .waitingFor(800)
                   .orDefaults(Authors.defaults());
@@ -47,7 +47,7 @@ Express constraints and react accordingly, throwing on an unfulfilled query, as
 an option to lenient handling with defaults.
 
 ```java
-  var offers = Queries.queryFor("offers/rental", Offer.class)
+  var offers = QueryBuilder.queryFor("offers/rental", Offer.class)
                   .takingAtLeast(10)
                   .takingAtMost(20)
                   .waitingFor(2, ChronoUnit.SECONDS)
@@ -58,7 +58,7 @@ Optional capabilities, to handle exceptions and errors are built-in and very
 easy to use.
 
 ```java
-  var offers = Queries.queryFor("offers/rental", NewOffer.class)
+  var offers = QueryBuilder.queryFor("offers/rental", NewOffer.class)
                   .takingAtLeast(3)
                   .waitingFor(400)
                   .onError(error -> LOG.error("Failure!", error))

--- a/examples/querying/src/main/java/app/Querying.java
+++ b/examples/querying/src/main/java/app/Querying.java
@@ -1,6 +1,6 @@
 package app;
 
-import com.studiomediatech.queryresponse.Queries;
+import com.studiomediatech.queryresponse.QueryBuilder;
 import com.studiomediatech.queryresponse.QueryResponseConfiguration;
 
 import org.slf4j.Logger;
@@ -41,7 +41,7 @@ class Querying implements CommandLineRunner {
 
         var defaults = List.of("Neuromancer", "I, Robot");
 
-        var results = Queries.queryFor("books/sci-fi", String.class)
+        var results = QueryBuilder.queryFor("books/sci-fi", String.class)
                 .waitingFor(888)
                 .orDefaults(defaults);
 
@@ -55,7 +55,7 @@ class Querying implements CommandLineRunner {
 
         LOG.info("Querying for authors...");
 
-        var authors = Queries.queryFor("authors", Author.class)
+        var authors = QueryBuilder.queryFor("authors", Author.class)
                 .takingAtLeast(3)
                 .waitingFor(888)
                 .orEmpty();

--- a/src/main/java/com/studiomediatech/queryresponse/Query.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Query.java
@@ -130,15 +130,15 @@ class Query<T> implements MessageListener, Logging {
     }
 
 
-    static <T> Query<T> valueOf(Queries<T> queries) {
+    static <T> Query<T> from(QueryBuilder<T> queryBuilder) {
 
         Query<T> query = new Query<>();
 
-        query.queryTerm = queries.getQueryForTerm();
-        query.responseType = queries.getType();
-        query.waitingFor = queries.getWaitingFor();
-        query.orDefaults = queries.getOrDefaults();
-        query.onError = queries.getOnError();
+        query.queryTerm = queryBuilder.getQueryForTerm();
+        query.responseType = queryBuilder.getType();
+        query.waitingFor = queryBuilder.getWaitingFor();
+        query.orDefaults = queryBuilder.getOrDefaults();
+        query.onError = queryBuilder.getOnError();
 
         return query;
     }

--- a/src/main/java/com/studiomediatech/queryresponse/QueryBuilder.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryBuilder.java
@@ -13,13 +13,13 @@ import java.util.function.Supplier;
 /**
  * Providing the entry-point to the fluid builder for queries, through the {@link #queryFor} method.
  *
- * <p>A {@link Queries queries-instance} is a container for a composed or configured query. It is is much like a
- * command-pattern object, providing all the properties required in order to publish the query, await responses and
- * return the results.</p>
+ * <p>A {@link QueryBuilder queryBuilder-instance} is a container for a composed or configured query. It is is much
+ * like a command-pattern object, providing all the properties required in order to publish the query, await responses
+ * and return the results.</p>
  *
  * @param  <T>  the <em>coerced</em> type of the query's response element {@link Collection collection}.
  */
-public final class Queries<T> {
+public final class QueryBuilder<T> {
 
     /**
      * The current implementation supports only term-based queries - that means, there may only be opaque semantics in
@@ -68,7 +68,7 @@ public final class Queries<T> {
     private Consumer<Throwable> onError;
 
     // Declared protected, for access in unit tests.
-    protected Queries(String term, Class<T> type) {
+    protected QueryBuilder(String term, Class<T> type) {
 
         this.type = type;
         this.queryForTerm = Asserts.invariantQueryTerm(term);
@@ -84,9 +84,9 @@ public final class Queries<T> {
      *
      * @return  a new queries builder, never {@code null}
      */
-    public static <T> Queries<T> queryFor(String term, Class<T> type) {
+    public static <T> QueryBuilder<T> queryFor(String term, Class<T> type) {
 
-        return new Queries<>(term, type);
+        return new QueryBuilder<>(term, type);
     }
 
 
@@ -97,7 +97,7 @@ public final class Queries<T> {
      *
      * @return  the query builder, for chaining further calls
      */
-    public Queries<T> waitingFor(long millis) {
+    public QueryBuilder<T> waitingFor(long millis) {
 
         this.waitingFor = Asserts.invariantDuration(Duration.ofMillis(millis));
 
@@ -113,7 +113,7 @@ public final class Queries<T> {
      *
      * @return  the query builder, for chaining further calls
      */
-    public Queries<T> waitingFor(long amount, TemporalUnit timeUnit) {
+    public QueryBuilder<T> waitingFor(long amount, TemporalUnit timeUnit) {
 
         this.waitingFor = Asserts.invariantDuration(Duration.of(amount, timeUnit));
 
@@ -128,7 +128,7 @@ public final class Queries<T> {
      *
      * @return  the query builder, for chaining further calls
      */
-    public Queries<T> waitingFor(Duration duration) {
+    public QueryBuilder<T> waitingFor(Duration duration) {
 
         this.waitingFor = Asserts.invariantDuration(duration);
 
@@ -143,7 +143,7 @@ public final class Queries<T> {
      *
      * @return  the query builder, for chaining further calls
      */
-    public Queries<T> takingAtMost(int atMost) {
+    public QueryBuilder<T> takingAtMost(int atMost) {
 
         this.takingAtMost = Asserts.invariantAtMost(atMost);
         assertTakingAtMostAndAtLeast();
@@ -160,7 +160,7 @@ public final class Queries<T> {
      *
      * @return  the query builder, for chaining further calls
      */
-    public Queries<T> takingAtLeast(int atLeast) {
+    public QueryBuilder<T> takingAtLeast(int atLeast) {
 
         this.takingAtLeast = Asserts.invariantAtLeast(atLeast);
         assertTakingAtMostAndAtLeast();
@@ -176,7 +176,7 @@ public final class Queries<T> {
      *
      * @return  the query builder, for chaining further calls
      */
-    public Queries<T> onError(Consumer<Throwable> handler) {
+    public QueryBuilder<T> onError(Consumer<Throwable> handler) {
 
         this.onError = handler;
 

--- a/src/main/java/com/studiomediatech/queryresponse/QueryRegistry.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryRegistry.java
@@ -58,7 +58,7 @@ class QueryRegistry implements ApplicationContextAware, Logging {
      * registered as a message listener and executed.
      *
      * @param  <T>  the type of elements in the returned collection
-     * @param  queries  configuration to use when initializing the {@link Query query} to register
+     * @param  queryBuilder  configuration to use when initializing the {@link Query query} to register
      *
      * @return  the collection of results from the executed query, which may be empty based on the configuration, but
      *          it never returns {@code null}
@@ -67,7 +67,7 @@ class QueryRegistry implements ApplicationContextAware, Logging {
      *                     {@link IllegalStateException} if the query registry could not be resolved, at the time of
      *                     the call.
      */
-    static <T> Collection<T> register(Queries<T> queries) {
+    static <T> Collection<T> register(QueryBuilder<T> queryBuilder) {
 
         var registry = instance.get();
 
@@ -75,21 +75,21 @@ class QueryRegistry implements ApplicationContextAware, Logging {
             throw new IllegalStateException("No registry is initialized.");
         }
 
-        return registry.accept(queries);
+        return registry.accept(queryBuilder);
     }
 
 
     /*
      * Declared protected, for access in unit-tests.
      */
-    protected <T> Collection<T> accept(Queries<T> queries) {
+    protected <T> Collection<T> accept(QueryBuilder<T> queryBuilder) {
 
         ensureDeclaredQueriesExchange();
 
         var queueName = declareQueryResponseQueue();
 
         try {
-            var query = Query.valueOf(queries);
+            var query = Query.from(queryBuilder);
 
             return query.publish(rabbitTemplate, queueName, listener);
         } finally {

--- a/src/test/java/com/studiomediatech/queryresponse/QueryBuilderApiTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryBuilderApiTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
 @ExtendWith(MockitoExtension.class)
-public class QueriesApiTest {
+public class QueryBuilderApiTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(QueriesApiTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QueryBuilderApiTest.class);
 
     @Mock
     QueryRegistry registry;
@@ -34,7 +34,7 @@ public class QueriesApiTest {
     @BeforeEach
     void setup() {
 
-        when(registry.accept(any(Queries.class))).thenReturn(Collections.emptyList());
+        when(registry.accept(any(QueryBuilder.class))).thenReturn(Collections.emptyList());
         QueryRegistry.instance = () -> registry;
     }
 
@@ -42,7 +42,7 @@ public class QueriesApiTest {
     @Test
     void ex1() {
 
-        var authors = Queries.queryFor("authors", String.class)
+        var authors = QueryBuilder.queryFor("authors", String.class)
                 .waitingFor(800)
                 .orEmpty();
     }
@@ -51,7 +51,7 @@ public class QueriesApiTest {
     @Test
     void ex2() {
 
-        var authors = Queries.queryFor("authors", String.class)
+        var authors = QueryBuilder.queryFor("authors", String.class)
                 .waitingFor(800)
                 .orDefaults(Authors.defaults());
     }
@@ -60,7 +60,7 @@ public class QueriesApiTest {
     @Test
     void ex3() {
 
-        var authors = Queries.queryFor("authors", String.class)
+        var authors = QueryBuilder.queryFor("authors", String.class)
                 .takingAtMost(10)
                 .waitingFor(800)
                 .orDefaults(Authors.defaults());
@@ -70,10 +70,9 @@ public class QueriesApiTest {
     @Test
     void ex4() {
 
-        var offers = Queries.queryFor("offers/rental", Offer.class)
+        var offers = QueryBuilder.queryFor("offers/rental", Offer.class)
                 .takingAtLeast(10)
-                .takingAtMost(20)
-                .waitingFor(2, ChronoUnit.SECONDS)
+                .takingAtMost(20).waitingFor(2, ChronoUnit.SECONDS)
                 .orThrow(TooFewOffersConstraintException::new);
     }
 
@@ -81,9 +80,8 @@ public class QueriesApiTest {
     @Test
     void ex5() {
 
-        var offers = Queries.queryFor("offers/rental", NewOffer.class)
-                .takingAtLeast(3)
-                .waitingFor(400)
+        var offers = QueryBuilder.queryFor("offers/rental", NewOffer.class)
+                .takingAtLeast(3).waitingFor(400)
                 .onError(error -> LOG.error("Failure!", error))
                 .orThrow(TooFewOffersConstraintException::new);
     }

--- a/src/test/java/com/studiomediatech/queryresponse/QueryBuilderTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryBuilderTest.java
@@ -7,47 +7,49 @@ import java.time.Duration;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
-class QueriesTest {
+class QueryBuilderTest {
 
     @Test
     void ensureThrowsOnTooLongQueryTerm() {
 
-        assertThrows(IllegalArgumentException.class, () -> Queries.queryFor("a".repeat(256), String.class));
+        assertThrows(IllegalArgumentException.class, () -> QueryBuilder.queryFor("a".repeat(256), String.class));
     }
 
 
     @Test
     void ensureThrowsForNullQueryTerm() {
 
-        assertThrows(IllegalArgumentException.class, () -> Queries.queryFor(null, String.class));
+        assertThrows(IllegalArgumentException.class, () -> QueryBuilder.queryFor(null, String.class));
     }
 
 
     @Test
     void ensureThrowsForEmptyQueryTerm() {
 
-        assertThrows(IllegalArgumentException.class, () -> Queries.queryFor("", String.class));
+        assertThrows(IllegalArgumentException.class, () -> QueryBuilder.queryFor("", String.class));
     }
 
 
     @Test
     void ensureThrowsForWhitespaceQueryTerm() {
 
-        assertThrows(IllegalArgumentException.class, () -> Queries.queryFor("     ", String.class));
+        assertThrows(IllegalArgumentException.class, () -> QueryBuilder.queryFor("     ", String.class));
     }
 
 
     @Test
     void ensureThrowsForZeroDuration() {
 
-        assertThrows(IllegalArgumentException.class, () -> Queries.queryFor("foobar", String.class).waitingFor(0L));
+        assertThrows(IllegalArgumentException.class,
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(0L));
     }
 
 
     @Test
     void ensureThrowsForNegativeDuration() {
 
-        assertThrows(IllegalArgumentException.class, () -> Queries.queryFor("foobar", String.class).waitingFor(-2L));
+        assertThrows(IllegalArgumentException.class,
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(-2L));
     }
 
 
@@ -56,7 +58,7 @@ class QueriesTest {
 
         Duration tooLong = Duration.ofMillis(Long.MAX_VALUE).plusMillis(1);
         assertThrows(IllegalArgumentException.class,
-            () -> Queries.queryFor("foobar", String.class).waitingFor(tooLong));
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(tooLong));
     }
 
 
@@ -64,7 +66,7 @@ class QueriesTest {
     void ensureThrowsForNegativeTakingAtMost() {
 
         assertThrows(IllegalArgumentException.class,
-            () -> Queries.queryFor("foobar", String.class).waitingFor(123).takingAtMost(-1));
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(123).takingAtMost(-1));
     }
 
 
@@ -72,7 +74,7 @@ class QueriesTest {
     void ensureThrowsForZeroTakingAtMost() {
 
         assertThrows(IllegalArgumentException.class,
-            () -> Queries.queryFor("foobar", String.class).waitingFor(123).takingAtMost(0));
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(123).takingAtMost(0));
     }
 
 
@@ -80,7 +82,7 @@ class QueriesTest {
     void ensureThrowsForNegativeTakingAtLeast() {
 
         assertThrows(IllegalArgumentException.class,
-            () -> Queries.queryFor("foobar", String.class).waitingFor(123).takingAtLeast(-1));
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(123).takingAtLeast(-1));
     }
 
 
@@ -88,7 +90,7 @@ class QueriesTest {
     void ensureThrowsForZeroTakingAtLeast() {
 
         assertThrows(IllegalArgumentException.class,
-            () -> Queries.queryFor("foobar", String.class).waitingFor(123).takingAtLeast(0));
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(123).takingAtLeast(0));
     }
 
 
@@ -96,7 +98,7 @@ class QueriesTest {
     void ensureThrowsForMoreTakingAtLeastThanAtMost() {
 
         assertThrows(IllegalArgumentException.class,
-            () -> Queries.queryFor("foobar", String.class).waitingFor(123).takingAtMost(1).takingAtLeast(2));
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(123).takingAtMost(1).takingAtLeast(2));
     }
 
 
@@ -104,6 +106,6 @@ class QueriesTest {
     void ensureThrowsForEqualTakingAtLeastAsAtMost() {
 
         assertThrows(IllegalArgumentException.class,
-            () -> Queries.queryFor("foobar", String.class).waitingFor(123).takingAtMost(1).takingAtLeast(1));
+            () -> QueryBuilder.queryFor("foobar", String.class).waitingFor(123).takingAtMost(1).takingAtLeast(1));
     }
 }

--- a/src/test/java/com/studiomediatech/queryresponse/QueryTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryTest.java
@@ -40,7 +40,7 @@ class QueryTest {
     @Test
     void ensureQueryIsPublished() {
 
-        var sut = Query.valueOf(Queries.queryFor("term", String.class).waitingFor(42));
+        var sut = Query.from(QueryBuilder.queryFor("term", String.class).waitingFor(42));
         sut.orDefaults = Collections::emptyList;
 
         sut.publish(rabbit, "queue-name", listener);
@@ -53,7 +53,7 @@ class QueryTest {
     @Test
     void ensureResponseIsConsumed() {
 
-        var sut = Query.valueOf(Queries.queryFor("term", String.class).waitingFor(42));
+        var sut = Query.from(QueryBuilder.queryFor("term", String.class).waitingFor(42));
 
         var response = MessageBuilder.withBody(("{'count': 3, 'total': 3, 'elements': ['foo', 'bar', 'baz']}")
                         .replaceAll("'", "\"").getBytes()).build();
@@ -68,7 +68,7 @@ class QueryTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        var sut = Query.valueOf(Queries.queryFor("term", Foo.class)
+        var sut = Query.from(QueryBuilder.queryFor("term", Foo.class)
                 .waitingFor(42)
                 .onError(err -> {
                     assertThat(err).isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
* Renaming this builder like class gives it a more expressive name.