### PR TITLE
Rename responses to `ResponseBuilder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,18 +76,18 @@ Very simple scenarios can quickly be created, for tests or proof of concept
 work.
 
 ```java
-  Responses.respondTo("authors")
-       .withAll()
-       .from("William Gibson", "Isaac Asimov", "J.R.R. Tolkien");
+  ResponseBuilder.respondTo("authors")
+      .withAll()
+      .from("William Gibson", "Isaac Asimov", "J.R.R. Tolkien");
 ```
 
 Batch responses provide developers with more options to tune and throttle a
 system using Query/Response across many services.
 
 ```java
-  Responses.respondTo("offers/monday")
-       .withBatchesOf(20)
-       .from(Offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
+  ResponseBuilder.respondTo("offers/monday")
+      .withBatchesOf(20)
+      .from(Offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
 ```
 
 AMQP Resources & Formats

--- a/examples/querying/src/main/java/app/Querying.java
+++ b/examples/querying/src/main/java/app/Querying.java
@@ -2,7 +2,6 @@ package app;
 
 import com.studiomediatech.queryresponse.EnableQueryResponse;
 import com.studiomediatech.queryresponse.QueryBuilder;
-import com.studiomediatech.queryresponse.QueryResponseConfiguration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,8 +10,6 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-
-import org.springframework.context.annotation.Import;
 
 import java.util.List;
 

--- a/examples/responding/src/main/java/app/Responding.java
+++ b/examples/responding/src/main/java/app/Responding.java
@@ -1,7 +1,7 @@
 package app;
 
 import com.studiomediatech.queryresponse.QueryResponseConfiguration;
-import com.studiomediatech.queryresponse.Responses;
+import com.studiomediatech.queryresponse.ResponseBuilder;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.WebApplicationType;
@@ -22,7 +22,7 @@ class Responding implements CommandLineRunner {
 
         println("Registering responses...");
 
-        Responses.respondTo("books/sci-fi")
+        ResponseBuilder.respondTo("books/sci-fi")
             .withAll()
             .from("Neuromancer", "Snow Crash", "I, Robot", "The Gods Themselves", "Pebble in the Sky");
 

--- a/src/main/java/com/studiomediatech/queryresponse/Response.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Response.java
@@ -36,7 +36,7 @@ class Response<T> implements MessageListener, Logging {
 
     private RabbitTemplate rabbitTemplate;
 
-    protected Response(Responses<T> responses) {
+    protected Response(ResponseBuilder<T> responses) {
 
         this.elements = responses.getElements();
         this.queueName = UUID.randomUUID().toString();
@@ -71,7 +71,7 @@ class Response<T> implements MessageListener, Logging {
     }
 
 
-    static <T> Response<T> valueOf(Responses<T> responses) {
+    static <T> Response<T> valueOf(ResponseBuilder<T> responses) {
 
         return new Response<>(responses);
     }

--- a/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
+++ b/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
@@ -11,7 +11,7 @@ import java.util.Collection;
  *
  * @param  <T>  the type of response entries or elements.
  */
-public class Responses<T> {
+public class ResponseBuilder<T> {
 
     /**
      * The current implementation supports only term-based queries - that means, there may only be opaque semantics in
@@ -29,18 +29,18 @@ public class Responses<T> {
     private Collection<T> elements;
 
     // Declared protected, for access in unit tests.
-    protected Responses(String term) {
+    protected ResponseBuilder(String term) {
 
         this.respondToTerm = Asserts.invariantQueryTerm(term);
     }
 
-    public static <T> Responses<T> respondTo(String term) {
+    public static <T> ResponseBuilder<T> respondTo(String term) {
 
-        return new Responses<>(term);
+        return new ResponseBuilder<>(term);
     }
 
 
-    public Responses<T> withAll() {
+    public ResponseBuilder<T> withAll() {
 
         this.batchSize = 0;
 
@@ -48,7 +48,7 @@ public class Responses<T> {
     }
 
 
-    public Responses<T> withBatchesOf(int size) {
+    public ResponseBuilder<T> withBatchesOf(int size) {
 
         this.batchSize = Asserts.invariantBatchSize(size);
 

--- a/src/main/java/com/studiomediatech/queryresponse/ResponseRegistry.java
+++ b/src/main/java/com/studiomediatech/queryresponse/ResponseRegistry.java
@@ -32,7 +32,7 @@ class ResponseRegistry implements ApplicationContextAware, Logging {
     }
 
 
-    public static <T> void register(Responses<T> responses) {
+    public static <T> void register(ResponseBuilder<T> responses) {
 
         var registry = instance.get();
 
@@ -44,7 +44,7 @@ class ResponseRegistry implements ApplicationContextAware, Logging {
     }
 
 
-    protected <T> void accept(Responses<T> responses) {
+    protected <T> void accept(ResponseBuilder<T> responses) {
 
         var response = Response.valueOf(responses);
 

--- a/src/test/java/com/studiomediatech/queryresponse/RabbitFacadeTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/RabbitFacadeTest.java
@@ -87,7 +87,7 @@ class RabbitFacadeTest {
 
         var sut = new RabbitFacade(admin, template, listener);
 
-        sut.declareQueue(new Response<>(new Responses<>("some-term")));
+        sut.declareQueue(new Response<>(new ResponseBuilder<>("some-term")));
 
         verify(admin).declareQueue(queue.capture());
 
@@ -102,7 +102,7 @@ class RabbitFacadeTest {
 
         var sut = new RabbitFacade(admin, template, listener);
 
-        var response = new Response<>(new Responses<>("some-term"));
+        var response = new Response<>(new ResponseBuilder<>("some-term"));
         sut.declareBinding(response);
 
         verify(admin).declareBinding(binding.capture());
@@ -118,7 +118,7 @@ class RabbitFacadeTest {
 
         var sut = new RabbitFacade(admin, template, listener);
 
-        var response = new Response<>(new Responses<>("some-term"));
+        var response = new Response<>(new ResponseBuilder<>("some-term"));
         sut.addListener(response);
 
         verify(listener).addQueueNames(queueName.capture());

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderApiTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderApiTest.java
@@ -11,18 +11,18 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class ResponsesApiTest {
+public class ResponseBuilderApiTest {
 
     @Test
     void ensureExamplesCompile() {
 
         ResponseRegistry.instance = () -> Mockito.mock(ResponseRegistry.class);
 
-        Responses.respondTo("authors")
+        ResponseBuilder.respondTo("authors")
             .withAll()
             .from("William Gibson", "Isaac Asimov", "J.R.R. Tolkien");
 
-        Responses.respondTo("offers/monday")
+        ResponseBuilder.respondTo("offers/monday")
             .withBatchesOf(20)
             .from(Offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
 

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
-class ResponsesTest {
+class ResponseBuilderTest {
 
     @Mock
     ResponseRegistry registry;
 
     @Captor
-    ArgumentCaptor<Responses<String>> responses;
+    ArgumentCaptor<ResponseBuilder<String>> responses;
 
     @BeforeEach
     void setup() {
@@ -42,7 +42,7 @@ class ResponsesTest {
     @DisplayName("responses with all sets batch size to 0")
     void ensureConfiguresBuilderCorrectlyForAll() {
 
-        Responses.respondTo("foobar").withAll().from("foo", "bar", "baz");
+        ResponseBuilder.respondTo("foobar").withAll().from("foo", "bar", "baz");
         verify(registry).register(responses.capture());
 
         assertThat(responses.getValue()).isNotNull();
@@ -57,7 +57,7 @@ class ResponsesTest {
     @DisplayName("responses with batch size is correctly set")
     void ensureConfiguresBuilderCorrectlyForBatches() {
 
-        Responses.respondTo("foobar").withBatchesOf(2).from("foo", "bar", "baz");
+        ResponseBuilder.respondTo("foobar").withBatchesOf(2).from("foo", "bar", "baz");
         verify(registry).register(responses.capture());
 
         assertThat(responses.getValue()).isNotNull();
@@ -71,7 +71,7 @@ class ResponsesTest {
     void ensureThrowsForNullResponseCollection() throws Exception {
 
         Collection<String> nope = null;
-        assertThrows(IllegalArgumentException.class, () -> Responses.<String>respondTo("foobar").withAll().from(nope));
+        assertThrows(IllegalArgumentException.class, () -> ResponseBuilder.<String>respondTo("foobar").withAll().from(nope));
     }
 
 
@@ -79,6 +79,6 @@ class ResponsesTest {
     void ensureThrowsForNullInResponseCollection() {
 
         assertThrows(IllegalArgumentException.class,
-            () -> Responses.respondTo("foobar").withAll().from(Arrays.asList("foo", null, "bar")));
+            () -> ResponseBuilder.respondTo("foobar").withAll().from(Arrays.asList("foo", null, "bar")));
     }
 }

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseRegistryTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseRegistryTest.java
@@ -47,7 +47,7 @@ class ResponseRegistryTest {
         assertThrows(IllegalStateException.class,
             () -> {
                 ResponseRegistry.instance = () -> null;
-                ResponseRegistry.register(new Responses<>("foobar"));
+                ResponseRegistry.register(new ResponseBuilder<>("foobar"));
             });
     }
 
@@ -59,7 +59,7 @@ class ResponseRegistryTest {
         var mock = Mockito.mock(ResponseRegistry.class);
         ResponseRegistry.instance = () -> mock;
 
-        Responses<Object> responses = new Responses<>("foobar");
+        ResponseBuilder<Object> responses = new ResponseBuilder<>("foobar");
         new ResponseRegistry(null).register(responses);
 
         verify(mock).accept(responses);
@@ -71,7 +71,7 @@ class ResponseRegistryTest {
     @Test
     void ensureAcceptResponses() throws Exception {
 
-        new ResponseRegistry(facade).accept(new Responses<>("some-term"));
+        new ResponseRegistry(facade).accept(new ResponseBuilder<>("some-term"));
 
         verify(facade).declareQueue(Mockito.isA(Response.class));
         verify(facade).declareBinding(Mockito.isA(Response.class));

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
@@ -37,7 +37,7 @@ class ResponseTest {
     @DisplayName("after consuming a query message, a response is published")
     void ensurePublishesResponseOnConsumedQueryMessage() {
 
-        var sut = Response.valueOf(new Responses<>("query-term"));
+        var sut = Response.valueOf(new ResponseBuilder<>("query-term"));
         sut.subscribe(rabbit, listener);
 
         var query = MessageBuilder.withBody("{}".getBytes()).setReplyTo("reply-to").build();


### PR DESCRIPTION
Align with the more smooth naming-scheme "builder", analog to `QueryBuilder`.