### PR TITLE
New lazy supplier API must have type hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Very simple scenarios can quickly be created, for tests or proof of concept
 work.
 
 ```java
-  ResponseBuilder.respondTo("authors")
+  ResponseBuilder.respondTo("authors", String.class)
       .withAll()
       .from("William Gibson", "Isaac Asimov", "J.R.R. Tolkien");
 ```
@@ -85,9 +85,18 @@ Batch responses provide developers with more options to tune and throttle a
 system using Query/Response across many services.
 
 ```java
-  ResponseBuilder.respondTo("offers/monday")
+  ResponseBuilder.respondTo("offers/monday", Offer.class)
       .withBatchesOf(20)
-      .from(Offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
+      .from(offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
+```
+
+Dynamic responses are easy to build, with an API that fits modern Java, using
+lazy calls to data sources.
+
+```java
+  ResponseBuilder.respondTo("users/current", Token.class)
+      .withBatchesOf(128)
+      .suppliedBy(userTokenService::findAllCurrentUserTokens);
 ```
 
 AMQP Resources & Formats

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,3 @@
-.PHONY: start
+.PHONY: up
 start:
-	docker-compose up -d
-.PHONY: stop
-stop:
-	docker-compose down
+	docker-compose up

--- a/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
+++ b/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
@@ -126,6 +126,9 @@ public class ResponseBuilder<T> {
     public void suppliedBy(Supplier<Collection<T>> supplier) {
 
         this.elements = () -> (Iterator<T>) supplier.get().iterator();
+        this.total = () -> supplier.get().size();
+
+        register();
     }
 
 

--- a/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
+++ b/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
@@ -57,14 +57,14 @@ public class ResponseBuilder<T> {
      *
      * @param  term  to respond to
      */
-    private ResponseBuilder(String term) {
+    private ResponseBuilder(String term, Class<T> type) {
 
         this.respondToTerm = Asserts.invariantQueryTerm(term);
     }
 
-    public static <T> ResponseBuilder<T> respondTo(String term) {
+    public static <T> ResponseBuilder<T> respondTo(String term, Class<T> type) {
 
-        return new ResponseBuilder<>(term);
+        return new ResponseBuilder<>(term, type);
     }
 
 
@@ -120,6 +120,12 @@ public class ResponseBuilder<T> {
         this.total = Asserts.invariantSupplier(total);
 
         register();
+    }
+
+
+    public void suppliedBy(Supplier<Collection<T>> supplier) {
+
+        this.elements = () -> (Iterator<T>) supplier.get().iterator();
     }
 
 

--- a/src/main/java/com/studiomediatech/queryresponse/Statistics.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Statistics.java
@@ -15,6 +15,7 @@ import java.net.UnknownHostException;
 
 import java.time.Duration;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 
@@ -30,11 +31,12 @@ class Statistics implements Logging {
 
         ResponseBuilder.respondTo("query-response/stats", String.class)
             .withAll()
-            .from( // NOSNAR
-                getApplicationNameOrDefault("app"), // NOSONAR
-                getHostnameOrDefault("unknown"), // NOSONAR
-                getPidOrDefault("-"), // NOSONAR
-                getUptimeOrDefault("-"));
+            .suppliedBy(() ->
+                    List.of( // NOSNAR
+                        getApplicationNameOrDefault("app"), // NOSONAR
+                        getHostnameOrDefault("unknown"), // NOSONAR
+                        getPidOrDefault("-"), // NOSONAR
+                        getUptimeOrDefault("-")));
     }
 
     private String getUptimeOrDefault(String defaults) {

--- a/src/main/java/com/studiomediatech/queryresponse/Statistics.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Statistics.java
@@ -28,7 +28,7 @@ class Statistics implements Logging {
         this.env = env;
         this.ctx = ctx;
 
-        ResponseBuilder.respondTo("query-response/stats")
+        ResponseBuilder.respondTo("query-response/stats", String.class)
             .withAll()
             .from( // NOSNAR
                 getApplicationNameOrDefault("app"), // NOSONAR

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderApiTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderApiTest.java
@@ -8,36 +8,63 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 
 public class ResponseBuilderApiTest {
 
     @Test
-    void ensureExamplesCompile() {
+    void ex1() {
 
         ResponseRegistry.instance = () -> Mockito.mock(ResponseRegistry.class);
 
-        ResponseBuilder.respondTo("authors")
+        ResponseBuilder.respondTo("authors", String.class)
             .withAll()
             .from("William Gibson", "Isaac Asimov", "J.R.R. Tolkien");
+    }
 
-        ResponseBuilder.respondTo("offers/monday")
+
+    @Test
+    void ex2() throws Exception {
+
+        Offers offers = new Offers();
+
+        ResponseBuilder.respondTo("offers/monday", Offer.class)
             .withBatchesOf(20)
-            .from(Offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
+            .from(offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
+    }
 
-        assertThat("no problems").isNotEmpty();
+
+    @Test
+    void ex3() throws Exception {
+
+        UserTokens userTokenService = new UserTokens();
+
+        ResponseBuilder.respondTo("users/current", Token.class)
+            .withBatchesOf(256)
+            .suppliedBy(userTokenService::findAllCurrentUserTokens);
     }
 
     private static class Offers {
 
-        public static Collection<Offer> findAllOffersByDayOfWeek(int dayOfWeek) {
+        public Collection<Offer> findAllOffersByDayOfWeek(int dayOfWeek) {
 
             return Collections.emptyList();
         }
     }
 
     static class Offer {
+
+        // OK
+    }
+
+    private static class UserTokens {
+
+        public Collection<Token> findAllCurrentUserTokens() {
+
+            return Collections.emptyList();
+        }
+    }
+
+    static class Token {
 
         // OK
     }

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderApiTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderApiTest.java
@@ -16,31 +16,26 @@ public class ResponseBuilderApiTest {
 
         ResponseRegistry.instance = () -> Mockito.mock(ResponseRegistry.class);
 
+        Offers offers = new Offers();
+        UserTokens userTokenService = new UserTokens();
+
+        // EXAMPLES --------
+
         ResponseBuilder.respondTo("authors", String.class)
             .withAll()
             .from("William Gibson", "Isaac Asimov", "J.R.R. Tolkien");
-    }
-
-
-    @Test
-    void ex2() throws Exception {
-
-        Offers offers = new Offers();
 
         ResponseBuilder.respondTo("offers/monday", Offer.class)
             .withBatchesOf(20)
             .from(offers.findAllOffersByDayOfWeek(Calendar.MONDAY));
-    }
-
-
-    @Test
-    void ex3() throws Exception {
-
-        UserTokens userTokenService = new UserTokens();
 
         ResponseBuilder.respondTo("users/current", Token.class)
             .withBatchesOf(256)
             .suppliedBy(userTokenService::findAllCurrentUserTokens);
+
+        // CLEANUP --------
+
+        ResponseRegistry.instance = () -> null;
     }
 
     private static class Offers {

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -36,9 +37,7 @@ class ResponseBuilderTest {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
 
-        ResponseBuilder.<String>respondTo("foobar", String.class)
-            .withSink(capture::set)
-            .withAll()
+        ResponseBuilder.<String>respondTo("foobar", String.class).withSink(capture::set).withAll()
             .from("hello", "world!");
 
         ResponseBuilder<String> builder = capture.get();
@@ -67,10 +66,7 @@ class ResponseBuilderTest {
 
         List<String> elements = List.of("foo", "bar", "baz");
 
-        ResponseBuilder.<String>respondTo("some-query", String.class)
-            .withSink(capture::set)
-            .withAll()
-            .from(elements);
+        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll().from(elements);
 
         ResponseBuilder<String> builder = capture.get();
         assertThat(builder).isNotNull();
@@ -88,9 +84,7 @@ class ResponseBuilderTest {
 
         var capture = new AtomicReference<ResponseBuilder<String>>(null);
 
-        ResponseBuilder.<String>respondTo("some-query", String.class)
-            .withSink(capture::set)
-            .withAll()
+        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll()
             .from("foo", "bar", "baz");
 
         ResponseBuilder<String> builder = capture.get();
@@ -111,9 +105,7 @@ class ResponseBuilderTest {
         Supplier<Iterator<String>> elements = List.of("foo", "bar", "baz")::iterator;
         Supplier<Integer> total = () -> 42;
 
-        ResponseBuilder.<String>respondTo("some-query", String.class)
-            .withSink(capture::set)
-            .withAll()
+        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll()
             .from(elements, total);
 
         ResponseBuilder<String> builder = capture.get();
@@ -126,14 +118,31 @@ class ResponseBuilderTest {
 
 
     @Test
+    @DisplayName("builder has supplied collection elements and total from elements size")
+    void ensureSuppliedByCollection() throws Exception {
+
+        var capture = new AtomicReference<ResponseBuilder<String>>(null);
+
+        Supplier<Collection<String>> elements = () -> List.of("foo", "bar", "baz");
+
+        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll()
+            .suppliedBy(elements);
+
+        ResponseBuilder<String> builder = capture.get();
+        assertThat(builder).isNotNull();
+
+        assertThat(builder.total().get()).isEqualTo(3);
+        assertThat(builder.elements()).isNotNull();
+        assertThat(asList(builder.elements().get())).containsExactly("foo", "bar", "baz");
+    }
+
+
+    @Test
     void ensureBuilderIsCollectionForSingleScalarVararg() throws Exception {
 
         var builder = new AtomicReference<ResponseBuilder<String>>(null);
 
-        ResponseBuilder.<String>respondTo("some-query", String.class)
-            .withSink(builder::set)
-            .withAll()
-            .from("foobar");
+        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(builder::set).withAll().from("foobar");
 
         ResponseBuilder<String> b = builder.get();
         assertThat(b).isNotNull();
@@ -153,10 +162,7 @@ class ResponseBuilderTest {
 
         var list = List.of("foo", "bar", "baz");
 
-        ResponseBuilder.respondTo("some-query", String.class)
-            .withSink(builder::set)
-            .withAll()
-            .from(list);
+        ResponseBuilder.respondTo("some-query", String.class).withSink(builder::set).withAll().from(list);
 
         @SuppressWarnings("unchecked")
         ResponseBuilder<String> b = (ResponseBuilder<String>) builder.get();
@@ -175,9 +181,7 @@ class ResponseBuilderTest {
 
         var builder = new AtomicReference<ResponseBuilder<?>>(null);
 
-        ResponseBuilder.respondTo("some-query", String.class)
-            .withSink(builder::set)
-            .withBatchesOf(3)
+        ResponseBuilder.respondTo("some-query", String.class).withSink(builder::set).withBatchesOf(3)
             .from("foo", "bar", "baz");
 
         ResponseBuilder<?> b = builder.get();
@@ -195,9 +199,7 @@ class ResponseBuilderTest {
         try {
             ResponseRegistry.instance = () -> registry;
 
-            ResponseBuilder.respondTo("foobar", String.class)
-                .withAll()
-                .from("foo", "bar", "baz");
+            ResponseBuilder.respondTo("foobar", String.class).withAll().from("foo", "bar", "baz");
 
             verify(registry).register(responses.capture());
 

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
@@ -36,7 +36,7 @@ class ResponseBuilderTest {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
 
-        ResponseBuilder.<String>respondTo("foobar")
+        ResponseBuilder.<String>respondTo("foobar", String.class)
             .withSink(capture::set)
             .withAll()
             .from("hello", "world!");
@@ -67,7 +67,7 @@ class ResponseBuilderTest {
 
         List<String> elements = List.of("foo", "bar", "baz");
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from(elements);
@@ -88,7 +88,7 @@ class ResponseBuilderTest {
 
         var capture = new AtomicReference<ResponseBuilder<String>>(null);
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from("foo", "bar", "baz");
@@ -111,7 +111,7 @@ class ResponseBuilderTest {
         Supplier<Iterator<String>> elements = List.of("foo", "bar", "baz")::iterator;
         Supplier<Integer> total = () -> 42;
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from(elements, total);
@@ -130,7 +130,7 @@ class ResponseBuilderTest {
 
         var builder = new AtomicReference<ResponseBuilder<String>>(null);
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(builder::set)
             .withAll()
             .from("foobar");
@@ -153,7 +153,7 @@ class ResponseBuilderTest {
 
         var list = List.of("foo", "bar", "baz");
 
-        ResponseBuilder.respondTo("some-query")
+        ResponseBuilder.respondTo("some-query", String.class)
             .withSink(builder::set)
             .withAll()
             .from(list);
@@ -175,7 +175,7 @@ class ResponseBuilderTest {
 
         var builder = new AtomicReference<ResponseBuilder<?>>(null);
 
-        ResponseBuilder.respondTo("some-query")
+        ResponseBuilder.respondTo("some-query", String.class)
             .withSink(builder::set)
             .withBatchesOf(3)
             .from("foo", "bar", "baz");
@@ -195,7 +195,7 @@ class ResponseBuilderTest {
         try {
             ResponseRegistry.instance = () -> registry;
 
-            ResponseBuilder.respondTo("foobar")
+            ResponseBuilder.respondTo("foobar", String.class)
                 .withAll()
                 .from("foo", "bar", "baz");
 

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseRegistryTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseRegistryTest.java
@@ -48,7 +48,7 @@ class ResponseRegistryTest {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from("foo", "bar", "baz");
@@ -67,7 +67,7 @@ class ResponseRegistryTest {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from("foo", "bar", "baz");
@@ -88,7 +88,7 @@ class ResponseRegistryTest {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from("foo", "bar", "baz");

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
@@ -42,7 +42,7 @@ class ResponseTest {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from("foo", "bar", "baz");
@@ -73,7 +73,7 @@ class ResponseTest {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
 
-        ResponseBuilder.<String>respondTo("some-query")
+        ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
             .from(() -> List.of("foo", "bar").iterator(), () -> 42);


### PR DESCRIPTION
This PR introduces 2 things, actually.

* Add the `suppliedBy(..)` terminal builder method, for responses.
* Add type hint argument to the `respondTo(..)` static factory builder method.

The new lazy, supplier API in the builder allows for a much cleaner, and easier I would say, way to ensure that responders actually _generate_ responses, and not just statically declaring them. This was of course always the intent; to have a fluid API which provides a blocking-call or imperative semantic, but allowing for dynamism in the actual generation of response data.

The very first move in that direction was the alternative with `Iterator`. It wasn't very pretty. I believe developers rather have `Stream` or `Collection` oriented APIs, since the `Iterator` has become less _attractive_.

So in introducing this new supplier, lazy API method, there was immediately Java generic type entropy disaster. That's why I'm opting for a type-hint at the static factory method, instead of juggling further with weird type hints in diamond operators and the like.

Perhaps there are better _tricks_ but after trying out some generics `extends` or `<? super T>` stuff, ending up with type warnings (in JDT/Eclipse anyway) I'll leave it for now.

