### PR TITLE
Remove total and count from envelope

### DIFF
--- a/src/main/java/com/studiomediatech/queryresponse/Query.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Query.java
@@ -252,10 +252,6 @@ class Query<T> implements MessageListener, Logging {
     static class ConsumedResponseEnvelope<R> {
 
         @JsonProperty
-        public int count;
-        @JsonProperty
-        public int total;
-        @JsonProperty
         public Collection<R> elements = new ArrayList<>();
 
         public static <R> ConsumedResponseEnvelope<R> empty() {
@@ -267,7 +263,7 @@ class Query<T> implements MessageListener, Logging {
         @Override
         public String toString() {
 
-            return "ConsumedResponseEnvelope [count=" + count + ", total=" + total + "]";
+            return "ConsumedResponseEnvelope [elements.size=" + elements.size() + "]";
         }
     }
 }

--- a/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
+++ b/src/main/java/com/studiomediatech/queryresponse/ResponseBuilder.java
@@ -30,13 +30,6 @@ public class ResponseBuilder<T> {
     private int batchSize = 0;
 
     /**
-     * The supplier of a total count of elements that a responder may be able to respond with. Can either be explicitly
-     * provided during build-time, in order to allow for lazily supplied responses. For known collections the supplier
-     * provides {@link Collection#size()}.
-     */
-    private Supplier<Integer> total;
-
-    /**
      * The supplier of the iterator, that provides elements for the built response. As the iterator may be lazily
      * provided, it may be that neither the builder or the created response has any control over the collection backing
      * the response.
@@ -97,7 +90,6 @@ public class ResponseBuilder<T> {
         var elements = Asserts.invariantResponseVarargsArray(ts);
 
         this.elements = elements::iterator;
-        this.total = elements::size;
 
         register();
     }
@@ -108,16 +100,14 @@ public class ResponseBuilder<T> {
         var elements = Asserts.invariantResponseCollection(ts);
 
         this.elements = elements::iterator;
-        this.total = elements::size;
 
         register();
     }
 
 
-    public void from(Supplier<Iterator<T>> elements, Supplier<Integer> total) {
+    public void from(Supplier<Iterator<T>> elements) {
 
         this.elements = Asserts.invariantSupplier(elements);
-        this.total = Asserts.invariantSupplier(total);
 
         register();
     }
@@ -126,7 +116,6 @@ public class ResponseBuilder<T> {
     public void suppliedBy(Supplier<Collection<T>> supplier) {
 
         this.elements = () -> (Iterator<T>) supplier.get().iterator();
-        this.total = null;
 
         register();
     }
@@ -147,12 +136,6 @@ public class ResponseBuilder<T> {
     int getBatchSize() {
 
         return this.batchSize;
-    }
-
-
-    Supplier<Integer> total() {
-
-        return this.total;
     }
 
 

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseBuilderTest.java
@@ -51,7 +51,6 @@ class ResponseBuilderTest {
     private List<String> asList(Iterator<String> iterator) {
 
         List<String> list = new ArrayList<>();
-
         iterator.forEachRemaining(list::add);
 
         return list;
@@ -59,79 +58,82 @@ class ResponseBuilderTest {
 
 
     @Test
-    @DisplayName("builder supplies iterator and correct count for collection")
-    void ensureBuilderSuppliesCollectionIteratorAndTotalCount() throws Exception {
+    @DisplayName("builder has iterator for provided collection")
+    void ensureBuilderHasCollectionIterator() throws Exception {
 
         var capture = new AtomicReference<ResponseBuilder<String>>(null);
 
         List<String> elements = List.of("foo", "bar", "baz");
 
-        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll().from(elements);
+        ResponseBuilder.<String>respondTo("some-query", String.class)
+            .withSink(capture::set)
+            .withAll()
+            .from(elements);
 
         ResponseBuilder<String> builder = capture.get();
         assertThat(builder).isNotNull();
 
-        assertThat(builder.total()).isNotNull();
-        assertThat(builder.total().get()).isEqualTo(3);
         assertThat(builder.elements()).isNotNull();
         assertThat(asList(builder.elements().get())).containsExactly("foo", "bar", "baz");
     }
 
 
     @Test
-    @DisplayName("builder supplies iterator and correct count for varargs")
-    void ensureBuilderSuppliesVarargsIteratorAndTotalCount() throws Exception {
+    @DisplayName("builder has iterator for varargs")
+    void ensureBuilderHasVarargsIterator() throws Exception {
 
         var capture = new AtomicReference<ResponseBuilder<String>>(null);
 
-        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll()
+        ResponseBuilder.<String>respondTo("some-query", String.class)
+            .withSink(capture::set)
+            .withAll()
             .from("foo", "bar", "baz");
 
         ResponseBuilder<String> builder = capture.get();
         assertThat(builder).isNotNull();
 
-        assertThat(builder.total().get()).isEqualTo(3);
         assertThat(builder.elements()).isNotNull();
         assertThat(asList(builder.elements().get())).containsExactly("foo", "bar", "baz");
     }
 
 
     @Test
-    @DisplayName("builder supplied iterator and total for suppliers")
-    void ensureBuilderSuppliesSuppliedIteratorAndTotalCount() throws Exception {
+    @DisplayName("builder has supplied iterator")
+    void ensureBuilderHasSuppliedIterator() throws Exception {
 
         var capture = new AtomicReference<ResponseBuilder<String>>(null);
 
         Supplier<Iterator<String>> elements = List.of("foo", "bar", "baz")::iterator;
-        Supplier<Integer> total = () -> 42;
 
-        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll()
-            .from(elements, total);
+        ResponseBuilder.<String>respondTo("some-query", String.class)
+            .withSink(capture::set)
+            .withAll()
+            .from(elements);
 
         ResponseBuilder<String> builder = capture.get();
         assertThat(builder).isNotNull();
 
-        assertThat(builder.total().get()).isEqualTo(42);
         assertThat(builder.elements()).isNotNull();
         assertThat(asList(builder.elements().get())).containsExactly("foo", "bar", "baz");
     }
 
 
     @Test
-    @DisplayName("builder has supplied collection elements and total from elements size")
+    @DisplayName("builder has supplied collection elements")
     void ensureSuppliedByCollection() throws Exception {
 
         var capture = new AtomicReference<ResponseBuilder<String>>(null);
 
         Supplier<Collection<String>> elements = () -> List.of("foo", "bar", "baz");
 
-        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(capture::set).withAll()
+        ResponseBuilder.<String>respondTo("some-query", String.class)
+            .withSink(capture::set)
+            .withAll()
             .suppliedBy(elements);
 
         ResponseBuilder<String> builder = capture.get();
         assertThat(builder).isNotNull();
 
-        assertThat(builder.total()).isNull();
         assertThat(builder.elements()).isNotNull();
         assertThat(asList(builder.elements().get())).containsExactly("foo", "bar", "baz");
     }
@@ -142,14 +144,16 @@ class ResponseBuilderTest {
 
         var builder = new AtomicReference<ResponseBuilder<String>>(null);
 
-        ResponseBuilder.<String>respondTo("some-query", String.class).withSink(builder::set).withAll().from("foobar");
+        ResponseBuilder.<String>respondTo("some-query", String.class)
+            .withSink(builder::set)
+            .withAll()
+            .from("foobar");
 
         ResponseBuilder<String> b = builder.get();
         assertThat(b).isNotNull();
 
         assertThat(b.getRespondToTerm()).isEqualTo("some-query");
         assertThat(b.getBatchSize()).isEqualTo(0);
-        assertThat(b.total().get()).isEqualTo(1);
         assertThat(b.elements()).isNotNull();
         assertThat(asList(b.elements().get())).containsExactly("foobar");
     }
@@ -162,7 +166,10 @@ class ResponseBuilderTest {
 
         var list = List.of("foo", "bar", "baz");
 
-        ResponseBuilder.respondTo("some-query", String.class).withSink(builder::set).withAll().from(list);
+        ResponseBuilder.respondTo("some-query", String.class)
+            .withSink(builder::set)
+            .withAll()
+            .from(list);
 
         @SuppressWarnings("unchecked")
         ResponseBuilder<String> b = (ResponseBuilder<String>) builder.get();
@@ -170,7 +177,6 @@ class ResponseBuilderTest {
 
         assertThat(b.getRespondToTerm()).isEqualTo("some-query");
         assertThat(b.getBatchSize()).isEqualTo(0);
-        assertThat(b.total().get()).isEqualTo(3);
         assertThat(b.elements()).isNotNull();
         assertThat(asList(b.elements().get())).containsExactly("foo", "bar", "baz");
     }
@@ -181,7 +187,9 @@ class ResponseBuilderTest {
 
         var builder = new AtomicReference<ResponseBuilder<?>>(null);
 
-        ResponseBuilder.respondTo("some-query", String.class).withSink(builder::set).withBatchesOf(3)
+        ResponseBuilder.respondTo("some-query", String.class)
+            .withSink(builder::set)
+            .withBatchesOf(3)
             .from("foo", "bar", "baz");
 
         ResponseBuilder<?> b = builder.get();
@@ -199,7 +207,9 @@ class ResponseBuilderTest {
         try {
             ResponseRegistry.instance = () -> registry;
 
-            ResponseBuilder.respondTo("foobar", String.class).withAll().from("foo", "bar", "baz");
+            ResponseBuilder.respondTo("foobar", String.class)
+                .withAll()
+                .from("foo", "bar", "baz");
 
             verify(registry).register(responses.capture());
 

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
@@ -59,12 +59,7 @@ class ResponseTest {
         Message m = message.getValue();
         assertThat(m).isNotNull();
 
-        JSONAssert.assertEquals(new String(m.getBody()),
-            "{"
-            + "count: 3,"
-            + "total: 3,"
-            + "elements: ['foo', 'bar', 'baz']"
-            + "}", true);
+        JSONAssert.assertEquals(new String(m.getBody()), "{elements: ['foo', 'bar', 'baz']}", true);
     }
 
 
@@ -77,7 +72,7 @@ class ResponseTest {
         ResponseBuilder.<String>respondTo("some-query", String.class)
             .withSink(capture::set)
             .withAll()
-            .from(() -> List.of("foo", "bar").iterator(), () -> 42);
+            .from(() -> List.of("foo", "bar").iterator());
 
         var sut = Response.from(capture.get());
         sut.accept(facade);
@@ -90,16 +85,12 @@ class ResponseTest {
         Message m = message.getValue();
         assertThat(m).isNotNull();
 
-        JSONAssert.assertEquals(new String(m.getBody()),
-            "{"
-            + "count: 2,"
-            + "total: 42,"
-            + "elements: ['foo', 'bar']"
-            + "}", true);
+        JSONAssert.assertEquals(new String(m.getBody()), "{elements: ['foo', 'bar']}", true);
     }
 
 
     @Test
+    @DisplayName("responses are published as batches of a given size, plus leftover")
     void ensurePublishedBatchResponses() throws Exception {
 
         AtomicReference<ResponseBuilder<String>> capture = new AtomicReference<>(null);
@@ -123,22 +114,8 @@ class ResponseTest {
         String json2 = new String(ms.get(1).getBody());
         String json3 = new String(ms.get(2).getBody());
 
-        JSONAssert.assertEquals(json1, "{"
-            + "count: 2,"
-            + "total: 5,"
-            + "elements: ['foo', 'bar']"
-            + "}", true);
-
-        JSONAssert.assertEquals(json2, "{"
-            + "count: 2,"
-            + "total: 5,"
-            + "elements: ['baz', 'goo']"
-            + "}", true);
-
-        JSONAssert.assertEquals(json3, "{"
-            + "count: 1,"
-            + "total: 5,"
-            + "elements: ['gar']"
-            + "}", true);
+        JSONAssert.assertEquals(json1, "{elements: ['foo', 'bar']}", true);
+        JSONAssert.assertEquals(json2, "{elements: ['baz', 'goo']}", true);
+        JSONAssert.assertEquals(json3, "{elements: ['gar']}", true);
     }
 }


### PR DESCRIPTION
* The projected total and the individual count of each response
  envelope, is now gone. The suggestion from @rjayasinghe was that
  it only mostly contributes to a confusion on how many elements
  to expect, as a consumer. In the more practical scenario, where
  there might be multiple responding instances, the total and
  count can never be used as expected - to assert how many more
  responses that may be delivered.

  Due to this, the envelope feature is not yet well enough thouhgt
  out - and also, not really needed.

  For the benefit of v0.9 it's certainly better to leave out.