### PR TITLE
Publish stats, instead of querying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     </properties>
 
     <parent>

--- a/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfiguration.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfiguration.java
@@ -1,25 +1,23 @@
 package com.studiomediatech.queryresponse;
 
-import com.studiomediatech.queryresponse.util.Logging;
-
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.support.GenericApplicationContext;
-
 import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.SchedulingConfiguration;
+
+import com.studiomediatech.queryresponse.util.Logging;
 
 
 /**
@@ -29,7 +27,7 @@ import org.springframework.core.env.Environment;
 @Configuration
 @ConditionalOnClass(RabbitAutoConfiguration.class)
 @AutoConfigureAfter(RabbitAutoConfiguration.class)
-@Import(RabbitAutoConfiguration.class)
+@Import({ RabbitAutoConfiguration.class, SchedulingConfiguration.class })
 @EnableConfigurationProperties(QueryResponseConfigurationProperties.class)
 class QueryResponseConfiguration implements Logging {
 
@@ -84,7 +82,7 @@ class QueryResponseConfiguration implements Logging {
     @Bean
     Statistics statistics(Environment env, ApplicationContext ctx, RabbitFacade facade) {
 
-        return new Statistics(env, ctx, facade);
+        return new Statistics(env, ctx, facade, props);
     }
 
 

--- a/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfiguration.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfiguration.java
@@ -75,14 +75,9 @@ class QueryResponseConfiguration implements Logging {
 
 
     @Bean
-    TopicExchange queryResponseTopicExchange() {
+    QueryResponseTopicExchange queryResponseTopicExchange() {
 
-        String name = props.getExchange().getName();
-
-        boolean durable = false;
-        boolean autoDelete = true;
-
-        return log(new TopicExchange(name, durable, autoDelete));
+        return log(new QueryResponseTopicExchange(props.getExchange().getName()));
     }
 
 

--- a/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfiguration.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfiguration.java
@@ -87,9 +87,9 @@ class QueryResponseConfiguration implements Logging {
 
 
     @Bean
-    Statistics statistics(Environment env, ApplicationContext ctx) {
+    Statistics statistics(Environment env, ApplicationContext ctx, RabbitFacade facade) {
 
-        return new Statistics(env, ctx);
+        return new Statistics(env, ctx, facade);
     }
 
 

--- a/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfigurationProperties.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfigurationProperties.java
@@ -10,33 +10,36 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class QueryResponseConfigurationProperties {
 
     private ExchangeProperties exchange = new ExchangeProperties();
-
     private QueueProperties queue = new QueueProperties();
+    private StatsProperties stats = new StatsProperties();
 
     public ExchangeProperties getExchange() {
-
         return exchange;
     }
 
-
     public void setExchange(ExchangeProperties exchange) {
-
         this.exchange = exchange;
     }
 
-
     public QueueProperties getQueue() {
-
         return queue;
     }
 
-
     public void setQueue(QueueProperties queue) {
-
         this.queue = queue;
     }
 
-    public static class ExchangeProperties {
+    public StatsProperties getStats() {
+		return stats;
+	}
+
+	public void setStats(StatsProperties stats) {
+		this.stats = stats;
+	}
+
+
+
+	public static class ExchangeProperties {
 
         /**
          * Name of the shared topic exchange for queries.
@@ -44,17 +47,15 @@ public class QueryResponseConfigurationProperties {
         private String name = "query-response";
 
         public String getName() {
-
             return name;
         }
 
-
         public void setName(String name) {
-
             this.name = name;
         }
     }
 
+	
     public static class QueueProperties {
 
         /**
@@ -63,14 +64,28 @@ public class QueryResponseConfigurationProperties {
         private String prefix = "query-response-";
 
         public String getPrefix() {
-
             return prefix;
         }
 
-
         public void setPrefix(String prefix) {
-
             this.prefix = prefix;
         }
+    }
+
+    
+    public static class StatsProperties {
+    	
+    	/**
+    	 * Topic or routing-key for statistics messages.
+    	 */
+    	private String topic = "query-response/internal/stats";
+
+		public String getTopic() {
+			return topic;
+		}
+
+		public void setTopic(String topic) {
+			this.topic = topic;
+		}
     }
 }

--- a/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfigurationProperties.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryResponseConfigurationProperties.java
@@ -79,6 +79,16 @@ public class QueryResponseConfigurationProperties {
     	 * Topic or routing-key for statistics messages.
     	 */
     	private String topic = "query-response/internal/stats";
+    	
+    	/**
+    	 * Initial delay, before the first published statistics after startup, in milliseconds.
+    	 */
+		private long initialDelay = 7000L;
+
+		/**
+		 * Delay between each publishing of statistics, in milliseconds.
+		 */
+		private long delay = 11000L;
 
 		public String getTopic() {
 			return topic;
@@ -86,6 +96,22 @@ public class QueryResponseConfigurationProperties {
 
 		public void setTopic(String topic) {
 			this.topic = topic;
+		}
+
+		public void setInitialDelay(long initialDelay) {
+			this.initialDelay = initialDelay;
+		}
+		
+		public long getInitialDelay() {
+			return initialDelay;
+		}
+
+		public void setDelay(long delay) {
+			this.delay = delay;
+		}
+		
+		public long getDelay() {
+			return delay;
 		}
     }
 }

--- a/src/main/java/com/studiomediatech/queryresponse/QueryResponseTopicExchange.java
+++ b/src/main/java/com/studiomediatech/queryresponse/QueryResponseTopicExchange.java
@@ -1,0 +1,23 @@
+package com.studiomediatech.queryresponse;
+
+import org.springframework.amqp.core.TopicExchange;
+
+/**
+ * Custom topic exchange type. 
+ */
+public class QueryResponseTopicExchange extends TopicExchange {
+
+	private static final boolean DURABLE = false;
+	private static final boolean AUTO_DELETE = true;
+
+	/**
+	 * Creates a new instance of the query response topic exchange.
+	 * 
+	 * @param name of the exchange
+	 */
+	public QueryResponseTopicExchange(String name) {
+		
+		super(name, DURABLE, AUTO_DELETE);
+	}
+
+}

--- a/src/main/java/com/studiomediatech/queryresponse/RabbitFacade.java
+++ b/src/main/java/com/studiomediatech/queryresponse/RabbitFacade.java
@@ -1,6 +1,7 @@
 package com.studiomediatech.queryresponse;
 
-import com.studiomediatech.queryresponse.util.Logging;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.AnonymousQueue;
@@ -17,11 +18,9 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.DirectMessageListenerContainer;
-
 import org.springframework.context.support.GenericApplicationContext;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import com.studiomediatech.queryresponse.util.Logging;
 
 
 /**
@@ -30,7 +29,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 class RabbitFacade implements Logging {
 
-    public static final String HEADER_X_QR_PUBLISHED = "x-qr-published";
+    private static final String QUERY_RESPONSE_INTERNAL_STATS_ROUTING_KEY = "query-response/internal/stats";
+	public static final String HEADER_X_QR_PUBLISHED = "x-qr-published";
 
     private final RabbitAdmin admin;
     private final ConnectionFactory connectionFactory;
@@ -244,4 +244,10 @@ class RabbitFacade implements Logging {
             .setHeader(HEADER_X_QR_PUBLISHED, System.currentTimeMillis())
             .build();
     }
+
+	protected void publishStats(Message message) {
+
+		this.template.send(queriesExchange.getName(), QUERY_RESPONSE_INTERNAL_STATS_ROUTING_KEY, decorateMessage(message));
+		logPublished("stats", QUERY_RESPONSE_INTERNAL_STATS_ROUTING_KEY, message);
+	}
 }

--- a/src/main/java/com/studiomediatech/queryresponse/RabbitFacade.java
+++ b/src/main/java/com/studiomediatech/queryresponse/RabbitFacade.java
@@ -29,7 +29,6 @@ import com.studiomediatech.queryresponse.util.Logging;
  */
 class RabbitFacade implements Logging {
 
-    private static final String QUERY_RESPONSE_INTERNAL_STATS_ROUTING_KEY = "query-response/internal/stats";
 	public static final String HEADER_X_QR_PUBLISHED = "x-qr-published";
 
     private final RabbitAdmin admin;
@@ -245,9 +244,9 @@ class RabbitFacade implements Logging {
             .build();
     }
 
-	protected void publishStats(Message message) {
+	protected void publishStats(Message message, String routingKey) {
 
-		this.template.send(queriesExchange.getName(), QUERY_RESPONSE_INTERNAL_STATS_ROUTING_KEY, decorateMessage(message));
-		logPublished("stats", QUERY_RESPONSE_INTERNAL_STATS_ROUTING_KEY, message);
+		this.template.send(queriesExchange.getName(), routingKey, decorateMessage(message));
+		logPublished("stats", routingKey, message);
 	}
 }

--- a/src/main/java/com/studiomediatech/queryresponse/Statistics.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Statistics.java
@@ -1,31 +1,12 @@
 package com.studiomediatech.queryresponse;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import com.studiomediatech.queryresponse.util.DurationFormatter;
-import com.studiomediatech.queryresponse.util.Logging;
-
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.EventListener;
-
-import org.springframework.core.env.Environment;
-
-import org.springframework.util.StringUtils;
-
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationTargetException;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -37,6 +18,16 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.studiomediatech.queryresponse.util.DurationFormatter;
+import com.studiomediatech.queryresponse.util.Logging;
 
 
 class Statistics implements Logging {
@@ -79,22 +70,17 @@ class Statistics implements Logging {
     protected Supplier<String> hostSupplier = () -> getHostnameOrDefault("unknown");
     protected Supplier<String> uptimeSupplier = () -> getUptimeOrDefault("-");
 
-    public Statistics(Environment env, ApplicationContext ctx) {
+	private final RabbitFacade facade;
+
+    public Statistics(Environment env, ApplicationContext ctx, RabbitFacade facade) {
 
         this.env = env;
         this.ctx = ctx;
+		this.facade = facade;
+		
         this.uuid = UUID.randomUUID().toString();
     }
 
-    @EventListener(ApplicationReadyEvent.class)
-    void respond() {
-
-        log().debug("Registering response for statistics queries...");
-
-        ChainingResponseBuilder.respondTo("query-response/stats", Stat.class)
-            .withAll()
-            .suppliedBy(this::getStats);
-    }
 
 
     protected Collection<Stat> getStats() {

--- a/src/main/java/com/studiomediatech/queryresponse/Statistics.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Statistics.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +26,6 @@ import java.util.stream.Stream;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
@@ -102,8 +102,8 @@ class Statistics implements Logging {
     protected void publishStats() {
     	
 		try {
-			String routingKey = props.getStats().getTopic();			
-			Message message = MessageBuilder.withBody(writer.writeValueAsBytes(Map.of("elements", getStats()))).build();
+			String routingKey = props.getStats().getTopic();
+			Message message = MessageBuilder.withBody(writer.writeValueAsBytes(getStatistics())).build();
 			
 			facade.publishStats(message, routingKey);
 		} catch (RuntimeException | JsonProcessingException ex) {
@@ -113,6 +113,13 @@ class Statistics implements Logging {
 		this.scheduler.schedule(this::publishStats, props.getStats().getDelay(), TimeUnit.MILLISECONDS);
     }
 
+    protected Map<String, Object> getStatistics() {
+    	
+    	Map<String, Object> target = new HashMap<>();
+    	target.put("elements", getStats());
+    	
+    	return target;    	
+    }
 
     protected Collection<Stat> getStats() {
 
@@ -366,7 +373,7 @@ class Statistics implements Logging {
 
         latencies.add(latency);
     }
-
+    
     @JsonInclude(Include.NON_NULL)
     public static final class Stat {
 

--- a/src/main/java/com/studiomediatech/queryresponse/Statistics.java
+++ b/src/main/java/com/studiomediatech/queryresponse/Statistics.java
@@ -86,9 +86,6 @@ class Statistics implements Logging {
 	private final RabbitFacade facade;
 	private final ScheduledExecutorService scheduler;
 
-	@Value("${queryresponse.stats.delay:11000}")
-	private Long queryresponseStatsDelay = 11000L;
-
     public Statistics(Environment env, ApplicationContext ctx, RabbitFacade facade, QueryResponseConfigurationProperties props) {
 
         this.env = env;

--- a/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
@@ -39,6 +39,9 @@ class QueryResponseConfigurationPropertiesTest {
     	
     	assertThat(sut.getStats()).isNotNull();
     	assertThat(sut.getStats().getTopic()).isEqualTo("query-response/internal/stats");
+    	assertThat(sut.getStats().getInitialDelay()).isEqualTo(7000L);
+    	assertThat(sut.getStats().getDelay()).isEqualTo(11000L);
+    	
 	}
     
     @Test
@@ -54,6 +57,8 @@ class QueryResponseConfigurationPropertiesTest {
     	
     	StatsProperties statsProps = new StatsProperties();
     	statsProps.setTopic("other-topic");
+    	statsProps.setInitialDelay(123L);
+    	statsProps.setDelay(1337L);
     	
 		sut.setExchange(exchangeProps);
 		sut.setQueue(queueProps);
@@ -62,7 +67,7 @@ class QueryResponseConfigurationPropertiesTest {
         assertThat(sut.getExchange().getName()).isEqualTo("other-exchange");
         assertThat(sut.getQueue().getPrefix()).isEqualTo("other-prefix");
         assertThat(sut.getStats().getTopic()).isEqualTo("other-topic");
-    	
-    	
+        assertThat(sut.getStats().getInitialDelay()).isEqualTo(123L);
+        assertThat(sut.getStats().getDelay()).isEqualTo(1337L);
 	}
 }

--- a/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
@@ -1,7 +1,6 @@
 package com.studiomediatech.queryresponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
@@ -1,8 +1,13 @@
 package com.studiomediatech.queryresponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+
+import com.studiomediatech.queryresponse.QueryResponseConfigurationProperties.ExchangeProperties;
+import com.studiomediatech.queryresponse.QueryResponseConfigurationProperties.QueueProperties;
+import com.studiomediatech.queryresponse.QueryResponseConfigurationProperties.StatsProperties;
 
 
 class QueryResponseConfigurationPropertiesTest {
@@ -34,5 +39,30 @@ class QueryResponseConfigurationPropertiesTest {
     	
     	assertThat(sut.getStats()).isNotNull();
     	assertThat(sut.getStats().getTopic()).isEqualTo("query-response/internal/stats");
+	}
+    
+    @Test
+	void ensureCanSetCustomConfiguration() throws Exception {
+		
+    	QueryResponseConfigurationProperties sut = new QueryResponseConfigurationProperties();
+    	
+    	ExchangeProperties exchangeProps = new ExchangeProperties();
+    	exchangeProps.setName("other-exchange");
+    	
+    	QueueProperties queueProps = new QueueProperties();
+    	queueProps.setPrefix("other-prefix");
+    	
+    	StatsProperties statsProps = new StatsProperties();
+    	statsProps.setTopic("other-topic");
+    	
+		sut.setExchange(exchangeProps);
+		sut.setQueue(queueProps);
+		sut.setStats(statsProps);
+				
+        assertThat(sut.getExchange().getName()).isEqualTo("other-exchange");
+        assertThat(sut.getQueue().getPrefix()).isEqualTo("other-prefix");
+        assertThat(sut.getStats().getTopic()).isEqualTo("other-topic");
+    	
+    	
 	}
 }

--- a/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryResponseConfigurationPropertiesTest.java
@@ -1,8 +1,8 @@
 package com.studiomediatech.queryresponse;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 
 class QueryResponseConfigurationPropertiesTest {
@@ -25,4 +25,14 @@ class QueryResponseConfigurationPropertiesTest {
         assertThat(props.getQueue()).isNotNull();
         assertThat(props.getQueue().getPrefix()).isEqualTo("query-response-");
     }
+    
+    @Test
+	void ensureCanConfigureStatsTopic() throws Exception {
+		
+    	
+    	QueryResponseConfigurationProperties sut = new QueryResponseConfigurationProperties();
+    	
+    	assertThat(sut.getStats()).isNotNull();
+    	assertThat(sut.getStats().getTopic()).isEqualTo("query-response/internal/stats");
+	}
 }

--- a/src/test/java/com/studiomediatech/queryresponse/QueryResponseTopicExchangeTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/QueryResponseTopicExchangeTest.java
@@ -1,0 +1,17 @@
+package com.studiomediatech.queryresponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class QueryResponseTopicExchangeTest {
+
+	@Test
+	void ensureQueryResponseTopicExchangeProperties() {
+		
+		QueryResponseTopicExchange sut = new QueryResponseTopicExchange("some-name");
+
+		assertThat(sut.isAutoDelete()).isTrue();
+		assertThat(sut.isDurable()).isFalse();
+	}
+}

--- a/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/ResponseTest.java
@@ -1,7 +1,6 @@
 package com.studiomediatech.queryresponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/studiomediatech/queryresponse/StatisticsTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/StatisticsTest.java
@@ -1,28 +1,18 @@
 package com.studiomediatech.queryresponse;
 
-import com.studiomediatech.queryresponse.Statistics.Stat;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import org.springframework.context.ApplicationContext;
-
-import org.springframework.mock.env.MockEnvironment;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
-import static org.mockito.Mockito.verify;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+import com.studiomediatech.queryresponse.Statistics.Stat;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -33,36 +23,13 @@ class StatisticsTest {
 
     @Mock
     ResponseRegistry registry;
+    
+    @Mock
+    RabbitFacade facade;
 
     @Captor
     ArgumentCaptor<ChainingResponseBuilder<?>> responses;
-
-    @SuppressWarnings("static-access")
-    @Test
-    void ensureBuildsResponseOnApplicationReady() throws InterruptedException {
-
-        ResponseRegistry.instance = () -> registry;
-
-        MockEnvironment env = new MockEnvironment();
-
-        new Statistics(env, ctx).respond();
-
-        verify(registry).register(responses.capture());
-
-        ChainingResponseBuilder<?> builder = responses.getValue();
-        assertThat(builder).isNotNull();
-
-        assertThat(builder.getRespondToTerm()).isEqualTo("query-response/stats");
-        assertThat(builder.elements().get()).isNotNull();
-        assertThat(builder.elements().get().hasNext()).isTrue();
-
-        List<Stat> stats = new ArrayList<>();
-        builder.elements().get().forEachRemaining(obj -> stats.add((Stat) obj));
-        assertThat(stats.stream().map(s -> s.key).collect(Collectors.toList())).contains("count_queries");
-
-        ResponseRegistry.instance = () -> null;
-    }
-
+    
 
     @Test
     void ensureMetaWithPublishingOnlyStatus() throws Exception {
@@ -70,7 +37,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         String key = "only_responses";
         Stat s1 = sut.getStats().stream().filter(s -> key.equals(s.key)).findFirst().get();
@@ -93,7 +60,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
         sut.pidSupplier = () -> "some-pid";
 
         String key = "pid";
@@ -112,7 +79,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
         sut.nameSupplier = () -> "some-name";
 
         String key = "name";
@@ -131,7 +98,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
         sut.hostSupplier = () -> "some-host";
 
         String key = "host";
@@ -150,7 +117,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
         sut.uptimeSupplier = () -> "some-uptime";
 
         String key = "uptime";
@@ -169,7 +136,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         String stat = "count_queries";
 
@@ -194,7 +161,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         String stat = "count_consumed_responses";
 
@@ -219,7 +186,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         String stat = "count_published_responses";
 
@@ -244,7 +211,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         String stat = "throughput_queries";
 
@@ -270,7 +237,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         String stat = "throughput_responses";
 
@@ -297,7 +264,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         String stat = "count_fallbacks";
 
@@ -320,7 +287,7 @@ class StatisticsTest {
     void ensureMeasuresAndRetainsLatencyStatisticsInBoundedCollection() throws Exception {
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx);
+        Statistics sut = new Statistics(env, ctx, facade);
 
         // NOOP
         sut.measureLatency(null, 43L);

--- a/src/test/java/com/studiomediatech/queryresponse/StatisticsTest.java
+++ b/src/test/java/com/studiomediatech/queryresponse/StatisticsTest.java
@@ -30,6 +30,8 @@ class StatisticsTest {
     @Captor
     ArgumentCaptor<ChainingResponseBuilder<?>> responses;
     
+    private QueryResponseConfigurationProperties props = new QueryResponseConfigurationProperties();
+    
 
     @Test
     void ensureMetaWithPublishingOnlyStatus() throws Exception {
@@ -37,7 +39,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         String key = "only_responses";
         Stat s1 = sut.getStats().stream().filter(s -> key.equals(s.key)).findFirst().get();
@@ -60,7 +62,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
         sut.pidSupplier = () -> "some-pid";
 
         String key = "pid";
@@ -79,7 +81,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
         sut.nameSupplier = () -> "some-name";
 
         String key = "name";
@@ -98,7 +100,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
         sut.hostSupplier = () -> "some-host";
 
         String key = "host";
@@ -117,7 +119,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
         sut.uptimeSupplier = () -> "some-uptime";
 
         String key = "uptime";
@@ -136,7 +138,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         String stat = "count_queries";
 
@@ -161,7 +163,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         String stat = "count_consumed_responses";
 
@@ -186,7 +188,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         String stat = "count_published_responses";
 
@@ -211,7 +213,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         String stat = "throughput_queries";
 
@@ -237,7 +239,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         String stat = "throughput_responses";
 
@@ -264,7 +266,7 @@ class StatisticsTest {
         ResponseRegistry.instance = () -> registry;
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         String stat = "count_fallbacks";
 
@@ -287,7 +289,7 @@ class StatisticsTest {
     void ensureMeasuresAndRetainsLatencyStatisticsInBoundedCollection() throws Exception {
 
         MockEnvironment env = new MockEnvironment();
-        Statistics sut = new Statistics(env, ctx, facade);
+        Statistics sut = new Statistics(env, ctx, facade, props);
 
         // NOOP
         sut.measureLatency(null, 43L);

--- a/ui/src/main/java/com/studiomediatech/SimpleWebSocketHandler.java
+++ b/ui/src/main/java/com/studiomediatech/SimpleWebSocketHandler.java
@@ -84,14 +84,21 @@ public class SimpleWebSocketHandler extends TextWebSocketHandler implements Logg
 
     public void handleLatency(long minLatency, long maxLatency, double avgLatency, List<Double> latencies) {
 
-        String json = String.format(Locale.US,
-                "{\"metrics\": {"
-                + (minLatency != -1 ? "\"min_latency\": %d," : "") + (maxLatency != -1 ? "\"max_latency\": %d," : "")
-                + "\"avg_latency\": %f,"
-                + "\"avg_latencies\": %s"
-                + "}}", minLatency, maxLatency, avgLatency, latencies);
-
-        publishTextMessageWithPayload(json);
+    	if (minLatency != -1 && maxLatency != -1) {  	
+	        publishTextMessageWithPayload(String.format(Locale.US,
+	                "{\"metrics\": {"
+	                + "\"min_latency\": %d," 
+	                + "\"max_latency\": %d,"
+	                + "\"avg_latency\": %f,"
+	                + "\"avg_latencies\": %s"
+	                + "}}", minLatency, maxLatency, avgLatency, latencies));
+    	} else {
+	        publishTextMessageWithPayload(String.format(Locale.US,
+	                "{\"metrics\": {"
+	                + "\"avg_latency\": %f,"
+	                + "\"avg_latencies\": %s"
+	                + "}}", avgLatency, latencies));    		
+    	}
     }
 
 

--- a/ui/src/main/resources/application.yaml
+++ b/ui/src/main/resources/application.yaml
@@ -1,2 +1,1 @@
 spring.application.name: query-response-ui
-logging.level.ROOT: DEBUG


### PR DESCRIPTION
This PR introduces a from-the-scratch rebuilt way for nodes, publishing statistics instead of using query-response.

After pondering this a long time, I've come to the conclusion that this _side channel_ of sorts, using a special topic or routing key. This way, the actual query-response core domain, is less affected by the meta-data and statistics information.

Right now, this seems to be the right thing to do.